### PR TITLE
fix missing library: NVActivityIndicatorView

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,9 +18,8 @@ let package = Package(
         .package(url: "https://github.com/SnapKit/SnapKit.git", .upToNextMajor(from: "5.0.1")),
         .package(url: "https://github.com/Moya/Moya.git", .upToNextMajor(from: "15.0.0")),
         .package(url: "https://github.com/Teknasyon-Teknoloji/PersistenceKit.git", .upToNextMajor(from: "1.4.0")),
-        .package(url: "https://github.com/devicekit/DeviceKit.git", .upToNextMajor(from: "4.0.0"))
-
-        
+        .package(url: "https://github.com/devicekit/DeviceKit.git", .upToNextMajor(from: "4.0.0")),
+        .package(url: "https://github.com/ninjaprox/NVActivityIndicatorView", .upToNextMajor(from: "5.1.1"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -31,8 +30,8 @@ let package = Package(
                 "SnapKit",
                 "Moya",
                 "PersistenceKit",
-                "DeviceKit"
-
+                "DeviceKit",
+                "NVActivityIndicatorView"
             ],
             path: "Sources"
             /*resources: [


### PR DESCRIPTION
## Problem
When I install Desk360 into my project with SPM, the compiler gives an error because the library (NVActivityIndicatorView) cannot be found. This pr aims to fix the problem by adding the NVActivityIndicatorView library to SPM.

## Impact
`Package.swift`

# Solution 🛠

This pr fixes the problem by adding the `NVActivityIndicatorView` library to `Package.swift`.

## How to test the changes locally 🧐
Add a simple new application project, try adding it with SPM and build it.

### Checklist ✅

* [x] The code architecture and patterns are consistent with the rest of the codebase.
* [x] The changes have been tested and following the [documented guidelines](https://github.com/Teknasyon-Teknoloji/desk360-ios-sdk/blob/master/CONTRIBUTING.md)
* [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
* [ ] In case the PR introduces changes that affect users, the documentation has been updated.
* [x] The code is fully tested and no breaking changes introduced to the core functionality.
